### PR TITLE
Psk export fix 

### DIFF
--- a/DAILibWV/DBAccess.cs
+++ b/DAILibWV/DBAccess.cs
@@ -990,6 +990,23 @@ namespace DAILibWV
             return res.ToArray();
         }
 
+        public static ChunkInformation GetGlobalChunkInformationById(byte[] id)
+        {
+            ChunkInformation res = new ChunkInformation();
+            res.id = id;
+            res.bundleIndex = -1;
+            SQLiteConnection con = GetConnection();
+            con.Open();
+            SQLiteDataReader reader = getAllWhere("globalchunks", "id = '" + Helpers.ByteArrayToHexString(id) + "'", con);
+            if (reader.Read())
+            {
+                res.id = Helpers.HexStringToByteArray((string)reader["id"]);
+                res.sha1 = Helpers.HexStringToByteArray((string)reader["sha1"]);
+            }
+            con.Close();
+            return res;
+        }
+
         #endregion
 
         #region initial scan stuff

--- a/DAIToolsWV/ContentTools/MeshTool.cs
+++ b/DAIToolsWV/ContentTools/MeshTool.cs
@@ -164,7 +164,7 @@ namespace DAIToolsWV.ContentTools
                     byte[] data = new byte[0];
                     if (toci.incas)
                     {
-                        DBAccess.ChunkInformation ci = DBAccess.GetChunkInformationById(id);
+                        DBAccess.ChunkInformation ci = GetChunkById(id);
                         if (ci.sha1 == null)
                             continue;
                         data = SHA1Access.GetDataBySha1(ci.sha1);
@@ -188,7 +188,7 @@ namespace DAIToolsWV.ContentTools
                                 data = c._data;
                         if (data.Length == 0)
                         {
-                            DBAccess.ChunkInformation ci = DBAccess.GetChunkInformationById(id);
+                            DBAccess.ChunkInformation ci = GetChunkById(id);
                             if (ci.sha1 == null)
                                 continue;
                             data = SHA1Access.GetDataBySha1(ci.sha1);
@@ -211,6 +211,16 @@ namespace DAIToolsWV.ContentTools
             {
                 status.Text = "General error, after state '" + status.Text + "' : " + ex.Message;
             }
+        }
+
+        private DBAccess.ChunkInformation GetChunkById(byte[] cid)
+        {
+            DBAccess.ChunkInformation ci = DBAccess.GetChunkInformationById(cid);
+            if (ci.sha1 == null)
+            {
+                ci = DBAccess.GetGlobalChunkInformationById(cid);
+            }
+            return ci;
         }
 
         private void listBox1_SelectedIndexChanged(object sender, EventArgs e)

--- a/DAIToolsWV/PSKFile.cs
+++ b/DAIToolsWV/PSKFile.cs
@@ -258,7 +258,7 @@ namespace DAIToolsWV
             foreach (DAILibWV.Frostbite.Mesh.MeshLOD lod in m.header.LODs) 
                 if(l == null)
                 foreach(DAILibWV.Frostbite.Mesh.MeshSection sec in lod.Sections)
-                    if (sec.VertexBuffer.Count != 0)
+                    if (sec.VertexBuffer != null && sec.VertexBuffer.Count != 0)
                     {
                         l = lod;
                         break;


### PR DESCRIPTION
These commits fix 2 issues with the MeshExporter : 
1/ in PSKFile, I added a check to check VertexBuffer is not null (the current code only checks that VertexBuffer.Count is > 0 but when the lod chunkID is not found and vertices not loaded, VertexBuffer ends up null)

2/ The higher lods of at least some meshes are located in global chunks and not in bundles chunks